### PR TITLE
Basic Enemy Movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The player can win the game using an exit `e` using `s`, but remember some exits
 
 `w` Shallow water
 
-`X` Enemy
+`Z` Enemy / Zombie (Slow moving and dumb)
 
 `/` Stairs
 

--- a/dockerfile
+++ b/dockerfile
@@ -14,4 +14,4 @@ RUN yarn --silent && npm link bs-platform && yarn build
 
 EXPOSE 3000
 
-CMD ["serve", "-s", "build", "-p", "3000"]
+CMD ["serve", "-s", "build", "-l", "3000"]

--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,6 @@
 FROM node:8.9.4
 
-RUN npm install -g serve react-scripts
+RUN npm install -g serve@6.5.8 react-scripts
 
 COPY package.json yarn.lock bsconfig.json  ./
 
@@ -14,4 +14,4 @@ RUN yarn --silent && npm link bs-platform && yarn build
 
 EXPOSE 3000
 
-CMD ["serve", "-s", "build", "-l", "3000"]
+CMD ["serve", "-s", "build", "-p", "3000"]

--- a/src/app/enemy.re
+++ b/src/app/enemy.re
@@ -123,7 +123,6 @@ module CreateEnemyLoop = (Pos: Types.Positions, Places: Types.Places, World: Wor
           |> w => {...game, world: w, player: player}
       })
     } else if (canSee(level.map, activeEnemy)) {
-      Js.Console.log("Chasing");
 
       let (dx, dy) = chase(level.map, activeEnemy);
       let (ox, oy) = activeEnemy.location;

--- a/src/app/enemy.re
+++ b/src/app/enemy.re
@@ -20,6 +20,7 @@ module CreateEnemyLoop = (Pos: Types.Positions, Places: Types.Places, World: Wor
     targets 
       |> List.filter(pos => {
         let (x, y) = pos;
+        Js.Console.log(string_of_int(x) ++ " " ++ string_of_int(y));
         Places.getPlace(x, y, area)
           |> Option.fmap(p => isPlayer(p))
           |> Option.default(false)
@@ -28,6 +29,10 @@ module CreateEnemyLoop = (Pos: Types.Positions, Places: Types.Places, World: Wor
 
   let findTargets = (~range=1, enemyInfo) => {
     let (x, y) = enemyInfo.location;
+    
+    let minX = x - range;
+    let maxX = x + range;
+
     let targetX = [(x-range), x, (x+range)] |> List.filter(x => x >= 0);
     let targetY = [(y-range), y, (y+range)] |> List.filter(y => y >= 0);
     targetY |> List.map(y => (targetX |> List.map(x => (x, y)))) |> List.flatten;

--- a/src/app/enemy.re
+++ b/src/app/enemy.re
@@ -20,7 +20,6 @@ module CreateEnemyLoop = (Pos: Types.Positions, Places: Types.Places, World: Wor
     targets 
       |> List.filter(pos => {
         let (x, y) = pos;
-        Js.Console.log(string_of_int(x) ++ " " ++ string_of_int(y));
         Places.getPlace(x, y, area)
           |> Option.fmap(p => isPlayer(p))
           |> Option.default(false)
@@ -32,10 +31,11 @@ module CreateEnemyLoop = (Pos: Types.Positions, Places: Types.Places, World: Wor
     
     let minX = x - range;
     let maxX = x + range;
+    let incRange = Rationale.RList.rangeInt(1);
 
-    let targetX = [(x-range), x, (x+range)] |> List.filter(x => x >= 0);
-    let targetY = [(y-range), y, (y+range)] |> List.filter(y => y >= 0);
-    targetY |> List.map(y => (targetX |> List.map(x => (x, y)))) |> List.flatten;
+    let targetX = incRange(minX, maxX) |> List.filter(x => x >= 0);
+    let targetY = incRange((y-range), (y+range)) |> List.filter(y => y >= 0);
+    targetY |> List.map(y => (targetX |> List.map(x => (x, y)))) |> List.flatten |> List.filter(xy => xy != (x, y));
   };
 
   let canAttack = (~range=1, area, enemyInfo) => {

--- a/src/app/types.re
+++ b/src/app/types.re
@@ -127,6 +127,7 @@ module type EnemyLoop = {
   let canAttack: (~range: int=?, area, enemyInfo) => bool;
   let attack: (enemyInfo, area) => option((area, player));
   let takeTurn: (enemyInfo, level, game) => option(game);
+  let chase: (~range: int=?, area, enemyInfo) => (int, int);
 };
 
 module type Game = {

--- a/src/app/world.re
+++ b/src/app/world.re
@@ -60,13 +60,19 @@ module Builder: WorldBuilder = {
     let level2 = LevelBuilder.makeBlankLevel("Dungeon 2")
       |> Level.modifyTile(0, 9, { tile: STAIRS({ id: 1, level: "Dungeon 1" }), state: Empty})
       |> Level.modifyTile(13, 1, { tile: STAIRS({ id: 0, level: "Dungeon 3" }), state: Empty})
+      |> Level.modifyTile(2, 2, {tile: GROUND, state: Enemy(newEnemy("z1"))})
+      |> Level.modifyTile(12, 12, {tile: GROUND, state: Enemy(newEnemy("z2"))})
       |> Level.modifyTiles([(4, 6), (5, 6), (6, 6), (7, 6), (5, 7), (6, 7), (5, 8), (6, 8)], Tiles.groundTile);
 
     let level3 = LevelBuilder.makeLevel("Dungeon 3", 18, 20, GROUND)
       |> Level.modifyTile(5, 18, { tile: STAIRS({ id: 1, level: "Dungeon 4" }), state: Empty})
       |> Level.modifyTile(13, 1, { tile: STAIRS({ id: 0, level: "Dungeon 2" }), state: Empty})
       |> Level.modifyTile(5, 8, { tile: EXIT(500), state: Empty})
-      |> Level.modifyTiles([(4, 6), (5, 6), (6, 6), (7, 6), (5, 7), (6, 7), (4, 8), (6, 8)], Tiles.wallTile);
+      |> Level.modifyTiles([(4, 6), (5, 6), (6, 6), (7, 6), (5, 7), (6, 7), (4, 8), (6, 8)], Tiles.wallTile)
+      |> Level.modifyTile(3, 4, {tile: GROUND, state: Enemy(newEnemy("z1"))})
+      |> Level.modifyTile(4, 7, {tile: GROUND, state: Enemy(newEnemy("z2"))})
+      |> Level.modifyTile(16, 17, {tile: GROUND, state: Enemy(newEnemy("z3"))})
+      |> Level.modifyTile(15, 9, {tile: GROUND, state: Enemy(newEnemy("z4"))})
 
     let level4 = LevelBuilder.makeBlankLevel("Dungeon 4")
       |> Level.modifyTile(2, 3, { tile: STAIRS({ id: 1, level: "Dungeon 3" }), state: Empty})
@@ -79,7 +85,12 @@ module Builder: WorldBuilder = {
     let level5 = LevelBuilder.makeLevel("Dungeon 5", 18, 20, GROUND)
       |> Level.modifyTile(5, 18, { tile: STAIRS({ id: 0, level: "Dungeon 4" }), state: Empty})
       |> Level.modifyTile(15, 1, { tile: EXIT(1000), state: Empty})
-      |> Level.modifyTiles([(4, 6), (5, 6), (6, 6), (7, 6), (5, 7), (6, 7), (5, 8), (6, 8)], Tiles.waterTile);
+      |> Level.modifyTiles([(4, 6), (5, 6), (6, 6), (7, 6), (5, 7), (6, 7), (5, 8), (6, 8)], Tiles.waterTile)
+      |> Level.modifyTile(15, 2, {tile: GROUND, state: Enemy(newEnemy("z1"))})
+      |> Level.modifyTile(14, 0, {tile: GROUND, state: Enemy(newEnemy("z2"))})
+      |> Level.modifyTile(10, 10, {tile: GROUND, state: Enemy(newEnemy("z3"))})
+      |> Level.modifyTile(6, 15, {tile: GROUND, state: Enemy(newEnemy("z4"))})
+      |> Level.modifyTile(18, 11, {tile: GROUND, state: Enemy(newEnemy("z5"))});
 
     { levels: [ initLevel(player), swamp, cave, level2, level3, level4, level5], current: "Dungeon 1"  }
   };

--- a/src/app/world.re
+++ b/src/app/world.re
@@ -60,8 +60,8 @@ module Builder: WorldBuilder = {
     let level2 = LevelBuilder.makeBlankLevel("Dungeon 2")
       |> Level.modifyTile(0, 9, { tile: STAIRS({ id: 1, level: "Dungeon 1" }), state: Empty})
       |> Level.modifyTile(13, 1, { tile: STAIRS({ id: 0, level: "Dungeon 3" }), state: Empty})
-      |> Level.modifyTile(2, 2, {tile: GROUND, state: Enemy(newEnemy("z1"))})
-      |> Level.modifyTile(12, 12, {tile: GROUND, state: Enemy(newEnemy("z2"))})
+      |> Level.modifyTile(3, 3, {tile: GROUND, state: Enemy(newEnemy("z1"))})
+      |> Level.modifyTile(11, 9, {tile: GROUND, state: Enemy(newEnemy("z2"))})
       |> Level.modifyTiles([(4, 6), (5, 6), (6, 6), (7, 6), (5, 7), (6, 7), (5, 8), (6, 8)], Tiles.groundTile);
 
     let level3 = LevelBuilder.makeLevel("Dungeon 3", 18, 20, GROUND)
@@ -71,7 +71,7 @@ module Builder: WorldBuilder = {
       |> Level.modifyTiles([(4, 6), (5, 6), (6, 6), (7, 6), (5, 7), (6, 7), (4, 8), (6, 8)], Tiles.wallTile)
       |> Level.modifyTile(3, 4, {tile: GROUND, state: Enemy(newEnemy("z1"))})
       |> Level.modifyTile(4, 7, {tile: GROUND, state: Enemy(newEnemy("z2"))})
-      |> Level.modifyTile(16, 17, {tile: GROUND, state: Enemy(newEnemy("z3"))})
+      |> Level.modifyTile(8, 10, {tile: GROUND, state: Enemy(newEnemy("z3"))})
       |> Level.modifyTile(15, 9, {tile: GROUND, state: Enemy(newEnemy("z4"))})
 
     let level4 = LevelBuilder.makeBlankLevel("Dungeon 4")

--- a/src/app/world.re
+++ b/src/app/world.re
@@ -76,7 +76,7 @@ module Builder: WorldBuilder = {
 
     let level4 = LevelBuilder.makeBlankLevel("Dungeon 4")
       |> Level.modifyTile(2, 3, { tile: STAIRS({ id: 1, level: "Dungeon 3" }), state: Empty})
-      |> Level.modifyTile(13, 12, { tile: STAIRS({ id: 0, level: "Dungeon 5" }), state: Empty})
+      |> Level.modifyTile(13, 12, { tile: STAIRS({ id: 0, level: "Dungeon 5" }), state: Enemy(newEnemy("z4"))})
       |> Level.modifyTile(7, 14, { tile: STAIRS({ id: 2, level: "Cave" }), state: Empty})
       |> Level.modifyTile(13, 11, {tile: GROUND, state: Enemy(newEnemy("z1"))})
       |> Level.modifyTile(0, 1, {tile: GROUND, state: Enemy(newEnemy("z2"))})

--- a/src/test/bouken_test.re
+++ b/src/test/bouken_test.re
@@ -38,7 +38,7 @@ describe("Game.MovePlayer", () => {
 });
 
 describe("Game.UseStairs", () => {
-  let initGame = Game.create("dave");
+  let initGame = Game.create("dasve");
   let newGame = initGame 
     |> Game.movePlayer(7, 8)
     >>= Game.useStairs

--- a/src/test/bouken_test.re
+++ b/src/test/bouken_test.re
@@ -38,7 +38,7 @@ describe("Game.MovePlayer", () => {
 });
 
 describe("Game.UseStairs", () => {
-  let initGame = Game.create("dasve");
+  let initGame = Game.create("dave");
   let newGame = initGame 
     |> Game.movePlayer(7, 8)
     >>= Game.useStairs

--- a/src/test/enemy_test.re
+++ b/src/test/enemy_test.re
@@ -107,13 +107,32 @@ describe("EnemyLoop", () => {
     });
   });
 
+  describe("find targets", () => {
+    
+    test("finds targets around the user", (_) => {
+      let (_, level) = gameWithEnemyDelta(0, 1, game);
+      let enemyInfo = { enemy: activeEnemy, location: (6, 7) }
+      let visiblePlaces = EnemyLoop.findTargets(~range=1, enemyInfo);
+
+      expect(List.length(visiblePlaces)) |> toBe(8);
+    });
+
+    test("finds more targets when a larger range is used", (_) => {
+      let (_, level) = gameWithEnemyDelta(0, 1, game);
+      let enemyInfo = { enemy: activeEnemy, location: (6, 7) }
+      let visiblePlaces = EnemyLoop.findTargets(~range=2, enemyInfo);
+
+      expect(List.length(visiblePlaces)) |> toBe(24);
+    });
+  });
+
   describe("chase", () => {
 
     let chase = (~range=4, area, enemyInfo) => {
 
       let visiblePlaces = EnemyLoop.findTargets(~range=range, enemyInfo);
       let playerLocations = EnemyLoop.attackablePlaces(visiblePlaces, area);
-      Js.Console.log(List.length(visiblePlaces) |> string_of_int);
+
       if (List.length(playerLocations) == 0) (9, 9)
       else {
         let loc = List.hd(playerLocations);

--- a/src/test/enemy_test.re
+++ b/src/test/enemy_test.re
@@ -128,55 +128,32 @@ describe("EnemyLoop", () => {
 
   describe("chase", () => {
 
-    let chase = (~range=4, area, enemyInfo) => {
-
-      let visiblePlaces = EnemyLoop.findTargets(~range=range, enemyInfo);
-      let playerLocations = EnemyLoop.attackablePlaces(visiblePlaces, area);
-
-      if (List.length(playerLocations) == 0) (9, 9)
-      else {
-        let loc = List.hd(playerLocations);
-        let (px, py) = loc;
-        
-        let (ex, ey) = enemyInfo.location;
-
-        let dx = ex - px;
-        let dy = ey - py;
-
-        let x = if(dx > 0) 1 else { if(dx == 0) 0 else -1 };
-        let y = if(dy > 0) 1 else { if(dy == 0) 0 else -1 };
-
-        (x, y)
-      }
-    };
-
     test("move north towards the player when the player is in range", (_) => {
-      let (_, level) = gameWithEnemyDelta(0, 1, game);
-      let result = chase(level.map, { enemy: activeEnemy, location: (6, 9) });
+      let (_, level) = gameWithEnemyDelta(0, -1, game);
+      let result = EnemyLoop.chase(level.map, { enemy: activeEnemy, location: (6, 5) });
 
       expect(result) |> toEqual((0, 1));
     });
 
     test("move west towards the player when the player is in range", (_) => {
-      let (_, level) = gameWithEnemyDelta(-4, 0, game);
-      let result = chase(level.map, { enemy: activeEnemy, location: (2, 6) });
+      let (_, level) = gameWithEnemyDelta(4, 0, game);
+      let result = EnemyLoop.chase(level.map, { enemy: activeEnemy, location: (10, 6) });
 
       expect(result) |> toEqual((-1, 0));
     });
 
     test("move south east towards the player when the player is in range", (_) => {
-      let (g, level) = gameWithEnemyDelta(1, -1, game);
-      let result = chase(level.map, { enemy: activeEnemy, location: (7, 5) });
+      let (_, level) = gameWithEnemyDelta(-1, 1, game);
+      let result = EnemyLoop.chase(level.map, { enemy: activeEnemy, location: (5, 7) });
 
       expect(result) |> toEqual((1, -1));
     });
 
-
     test("does not move when the player is out of range", (_) => {
       let (_, level) = gameWithEnemyDelta(6, 6, game);
-      let result = chase(level.map, { enemy: activeEnemy, location: (12, 12)} );
+      let result = EnemyLoop.chase(level.map, { enemy: activeEnemy, location: (12, 12)} );
 
-      expect(result) |> toEqual((9, 9));
+      expect(result) |> toEqual((0, 0));
     });
   });
 });

--- a/src/test/enemy_test.re
+++ b/src/test/enemy_test.re
@@ -104,4 +104,27 @@ describe("EnemyLoop", () => {
       expect(canAttack) |> toBe(false);
     });
   });
+
+  describe("move", () => {
+
+    let loc = (~range=2, area, enemyInfo) => {
+
+      (1, 1)
+    };
+
+
+    test("moves towards the player when the player is in range", (_) => {
+      let (_, level) = gameWithAttackablePlayer(game);
+      let canAttack = loc(level.map, { enemy: activeEnemy, location: (6, 7)} );
+
+      expect(canAttack) |> toEqual((1, 1));
+    });
+
+    test("does not move when the player is out of range", (_) => {
+      let (_, level) = gameWithAttackablePlayer(game);
+      let canAttack = loc(level.map, { enemy: activeEnemy, location: (3, 3)} );
+
+      expect(canAttack) |> toEqual((1, 1));
+    });
+  });
 });

--- a/src/test/enemy_test.re
+++ b/src/test/enemy_test.re
@@ -110,7 +110,6 @@ describe("EnemyLoop", () => {
   describe("find targets", () => {
     
     test("finds targets around the user", (_) => {
-      let (_, level) = gameWithEnemyDelta(0, 1, game);
       let enemyInfo = { enemy: activeEnemy, location: (6, 7) }
       let visiblePlaces = EnemyLoop.findTargets(~range=1, enemyInfo);
 
@@ -118,7 +117,6 @@ describe("EnemyLoop", () => {
     });
 
     test("finds more targets when a larger range is used", (_) => {
-      let (_, level) = gameWithEnemyDelta(0, 1, game);
       let enemyInfo = { enemy: activeEnemy, location: (6, 7) }
       let visiblePlaces = EnemyLoop.findTargets(~range=2, enemyInfo);
 
@@ -147,6 +145,13 @@ describe("EnemyLoop", () => {
       let result = EnemyLoop.chase(level.map, { enemy: activeEnemy, location: (5, 7) });
 
       expect(result) |> toEqual((1, -1));
+    });
+
+    test("does not move if the tile is occupied by another enemy", (_) => {
+      let (_, level) = gameWithEnemyDelta(0, -1, game);
+      let result = EnemyLoop.chase(level.map, { enemy: activeEnemy, location: (6, 5) });
+
+      expect(result) |> toEqual((0, 1));
     });
 
     test("does not move when the player is out of range", (_) => {

--- a/src/ui/GameMap.re
+++ b/src/ui/GameMap.re
@@ -8,7 +8,7 @@ module GameElements = {
   switch place.state {
   | Empty => default
   | Player(_) => "O"
-  | Enemy(_) => "X"
+  | Enemy(_) => "Z"
   };
 
   let tilesToElements = List.map(t =>


### PR DESCRIPTION
Simple "chase" logic triggered when the player gets too close. If it's simple to do take walls into account,  if not that can be postponed to an enhancement.

- [x] Fix enemy targeting for larger ranges
- [x] Add additional choice to enemy loop (wait, attack, or chase)
- [x] Enemies should stop when the player is out of sight / range
- [x] Use a different key for enemies, since these enemies are super dumb perhaps `Z` for zombie?
- [x] Tweak any empty levels to include some enemies
- [x] Prevent enemies from walking on to the same tile