### PR TITLE
Terrain Penalties

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The player can win the game using an exit `e` using `s`, but remember some exits
 
 `#` Wall
 
-`w` Shallow water
+`w` Shallow water (Slows all actions)
 
 `Z` Enemy / Zombie (Slow moving and dumb)
 

--- a/src/app.re
+++ b/src/app.re
@@ -63,7 +63,7 @@ let make = (_children) => {
       | Begin(game) => ReasonReact.Update(InGame(game))
       };
   },
-  render: (self) => {
+  render: (self) =>
     <div className="App">
       (switch self.state {
       | Home => 
@@ -83,6 +83,5 @@ let make = (_children) => {
             movePlayer=((x, y) => self.send(GameAction(MovePlayer(x, y))))
           />
       })
-    </div>
-    },
+    </div>,
 };

--- a/src/app/bouken.re
+++ b/src/app/bouken.re
@@ -48,12 +48,10 @@ module CreateGame: ((Types.GameLoop, Types.World, Types.WorldBuilder) => (Types.
       }
       | _ => None 
     };
-    
-    let reducedPlayer = { ... player, stats: { ... player.stats, position: player.stats.position -. 1. } };
-      
+          
     let updateLevelWithPlayer = level => {
       level.map 
-        |> Area.setPlayerAt(xl, yl, reducedPlayer, 0.)
+        |> Area.setPlayerAt(xl, yl, player, 1.)
         |> Option.ofResult
         |> Option.fmap(area => { ... level, map: area });
     };
@@ -111,17 +109,14 @@ module CreateGame: ((Types.GameLoop, Types.World, Types.WorldBuilder) => (Types.
 
     let attemptMove(level, x, y) = level |> 
       Option.bind(_, l =>
-          l.map |> Area.movePlayer(x, y, 1.) |>
-              Option.ofResult |> o => switch o {
-                  | Some(area) => Some(area)
-                  | None => None
-                  }
-              |> Option.fmap((pa:playerArea) => {
-                  let nl = { ... l, map: pa.area};
-                  let world = W.updateLevel(nl, game.world);
+          l.map |> Area.movePlayer(x, y, 1.) 
+                |> Option.ofResult
+                |> Option.fmap((pa:playerArea) => {
+                    let nl = { ... l, map: pa.area};
+                    let world = W.updateLevel(nl, game.world);
 
-                  {... game, player: pa.player, world: world };
-              }))
+                    {... game, player: pa.player, world: world };
+                }))
       |> Option.fmap(GL.continue)
       |> optRes => switch optRes {
         | Some(game) => gameToRes(game)

--- a/src/app/bouken.re
+++ b/src/app/bouken.re
@@ -84,15 +84,15 @@ module CreateGame: ((Types.GameLoop, Types.World, Types.WorldBuilder) => (Types.
 
       game |> applyBonus;
     };
-
+    let module G = Gameutil.GameUtil(Area, W);
     level 
       >>= findPlaceToAttack 
       >>= attackPlace
       >>= (p => level |> Option.fmap(Level.modifyTile(tx, ty, p)) )
       >>= updateLevelWithPlayer
-      |> Option.fmap(l => World.World.updateLevel(l, game.world))
-      |> Option.fmap(w => { ... game, world: w})
+      |> Option.fmap(l => G.update(l.map, game))
       >>= goldBonus(tx, ty)
+      |> Option.fmap(GL.continue)
       |> Option.fmap(gameToRes)
       |> Option.default(Error("Unable to attack"))
   };
@@ -114,8 +114,7 @@ module CreateGame: ((Types.GameLoop, Types.World, Types.WorldBuilder) => (Types.
                 |> Option.fmap((pa:playerArea) => {
                     let nl = { ... l, map: pa.area};
                     let world = W.updateLevel(nl, game.world);
-
-                    {... game, player: pa.player, world: world };
+                    { ... game, player: pa.player, world: world };
                 }))
       |> Option.fmap(GL.continue)
       |> optRes => switch optRes {

--- a/src/app/enemy.re
+++ b/src/app/enemy.re
@@ -87,7 +87,7 @@ module CreateEnemyLoop = (Pos: Types.Positions, Places: Types.Places, World: Wor
             | _ => None;
           })
         |> Option.fmap((player:player) => { ...player, stats: {...player.stats, health: player.stats.health - 1} } )
-        >>= (player => Places.setPlayerAt(x, y, player, 1., area) 
+        >>= (player => Places.setPlayerAt(x, y, player, 0., area) 
           |> Option.ofResult 
           |> Option.fmap(area => (area, player)));
       } else {

--- a/src/app/enemy.re
+++ b/src/app/enemy.re
@@ -81,12 +81,13 @@ module CreateEnemyLoop = (Pos: Types.Positions, Places: Types.Places, World: Wor
       let (x,y) = List.hd(targets);
       let place = Places.getPlace(x, y, area);
 
+
       place >>= (place =>
           switch place.state {
             | Player(p) => Some(p)
             | _ => None;
           })
-        |> Option.fmap((player:player) => { ...player, stats: {...player.stats, health: player.stats.health - 1} } )
+        |> Option.fmap((player:player) => { ...player, stats: {...player.stats, health: player.stats.health - 1} })
         >>= (player => Places.setPlayerAt(x, y, player, 0., area) 
           |> Option.ofResult 
           |> Option.fmap(area => (area, player)));

--- a/src/app/enemy.re
+++ b/src/app/enemy.re
@@ -87,7 +87,7 @@ module CreateEnemyLoop = (Pos: Types.Positions, Places: Types.Places, World: Wor
             | _ => None;
           })
         |> Option.fmap((player:player) => { ...player, stats: {...player.stats, health: player.stats.health - 1} } )
-        >>= (player => Places.setPlayerAt(x, y, player, 0., area) 
+        >>= (player => Places.setPlayerAt(x, y, player, 1., area) 
           |> Option.ofResult 
           |> Option.fmap(area => (area, player)));
       } else {

--- a/src/app/enemy.re
+++ b/src/app/enemy.re
@@ -81,13 +81,12 @@ module CreateEnemyLoop = (Pos: Types.Positions, Places: Types.Places, World: Wor
       let (x,y) = List.hd(targets);
       let place = Places.getPlace(x, y, area);
 
-
       place >>= (place =>
           switch place.state {
             | Player(p) => Some(p)
             | _ => None;
           })
-        |> Option.fmap((player:player) => { ...player, stats: {...player.stats, health: player.stats.health - 1} })
+        |> Option.fmap((player:player) => { ...player, stats: {...player.stats, health: player.stats.health - 1} } )
         >>= (player => Places.setPlayerAt(x, y, player, 0., area) 
           |> Option.ofResult 
           |> Option.fmap(area => (area, player)));

--- a/src/app/gameutil.re
+++ b/src/app/gameutil.re
@@ -1,0 +1,17 @@
+open Types;
+open Rationale.Option;
+
+module GameUtil = (P:Places, W:World) => {
+
+  let updateCurrentLevel = (area, game) => 
+    W.currentLevel(game.world) 
+      |> fmap(lvl => { ... lvl, map: area })
+      |> fmap(lvl => W.updateLevel(lvl, game.world));
+
+  let attemptUpdate = (area, game) =>
+    P.findPlayer(area) 
+      |> fmap(player => { ... game, player: player })
+      >>= gam => updateCurrentLevel(area, gam) <$> (world => { ... gam, world: world });
+
+  let update = (area, game) => attemptUpdate(area, game) |> default(game);
+};

--- a/src/app/level.re
+++ b/src/app/level.re
@@ -159,13 +159,13 @@ module Area: Places = {
   };
 
   let setPlayerLocation = (x: int, y: int, cost: float, area: area) => {
-    let update = (player, map) => {
+    let update = (playerFunc, map) => {
       map |>
       List.mapi((xi: int, xs: list(place)) =>
         if (xi == y) {
             xs |> List.mapi((yi: int, place: place) =>
             if (yi == x) { 
-              let np = player(place.tile);
+              let np:player = playerFunc(place.tile);
               { ...place, state: Player({ ...np, location: (x, y) }) }
             } else place);
         } else xs
@@ -250,7 +250,7 @@ module Area: Places = {
         area |> canMoveTo(~overwrite=false, nx, ny)
           >>= _ => setPlayerLocation(nx, ny, cost, area)
           |> Result.fmap(removeOccupant(xl, yl))
-          |> Result.fmap(a => {player: newPlayer, area: a})
+          |> Result.fmap(a => { player: newPlayer, area: a})
       }
       | None => error(InvalidState);
     };

--- a/src/app/level.re
+++ b/src/app/level.re
@@ -134,16 +134,15 @@ module Area: Places = {
   let canMoveTo = (~overwrite=true, x, y, map: area) => {
     open Rationale.Option;
     
-    map 
-    |> RList.nth(y) >>= RList.nth(x)
-    |> Result.ofOption(ImpossibleMove)
-    |> Result.bind(_, l => switch l.tile {
-        | GROUND => if (isEmpty(l) || overwrite) success(l) else error(ImpossibleMove)
-        | WATER => success(l)
-        | WALL => error(ImpossibleMove)
-        | STAIRS(_) => success(l)
-        | EXIT(_) => success(l)
-    });
+    map |> RList.nth(y) >>= RList.nth(x)
+        |> Result.ofOption(ImpossibleMove)
+        |> Result.bind(_, l => switch l.tile {
+            | GROUND => if (isEmpty(l) || overwrite) success(l) else error(ImpossibleMove)
+            | WATER => success(l)
+            | WALL => error(ImpossibleMove)
+            | STAIRS(_) => success(l)
+            | EXIT(_) => success(l)
+        });
   };
     
   let removeOccupant = (x, y, area) => {
@@ -303,20 +302,20 @@ module Level = {
           | Some(result) => success(result)
           })
   };
-
+  
   let movePlayer(x: int, y: int, level: level) = {
     let playerOpt = findPlayer(level);
     switch(playerOpt) {
-    | Some(player) => {
-      let (xl, yl) = player.location;
-      let nx = x + xl;
-      let ny = y + yl;
+      | Some(player) => {
+        let (xl, yl) = player.location;
+        let nx = x + xl;
+        let ny = y + yl;
 
-      level 
-        |> setPlayerLocation(nx, ny)
-        |> Result.fmap(removeOccupant(xl, yl))
-    }
-    | None => error(InvalidState);
+        level 
+          |> setPlayerLocation(nx, ny)
+          |> Result.fmap(removeOccupant(xl, yl))
+      }
+      | None => error(InvalidState);
     };
   };
 };

--- a/src/app/level.re
+++ b/src/app/level.re
@@ -240,16 +240,16 @@ module Area: Places = {
     let playerOpt = findPlayer(area);
     switch(playerOpt) {
       | Some(player) => {
-        let (xl, yl) = player.location;
-        let nx = x + xl;
-        let ny = y + yl;
+          let (xl, yl) = player.location;
+          let nx = x + xl;
+          let ny = y + yl;
 
-        let newPlayer = { ... player, location: (nx, ny)};
+          let newPlayer = { ... player, location: (nx, ny)};
 
-        area |> canMoveTo(~overwrite=false, nx, ny)
-          >>= _ => setPlayerLocation(nx, ny, cost, area)
-          |> Result.fmap(removeOccupant(xl, yl))
-          |> Result.fmap(a => { player: newPlayer, area: a})
+          area |> canMoveTo(~overwrite=false, nx, ny)
+            >>= _ => setPlayerLocation(nx, ny, cost, area)
+            |> Result.fmap(removeOccupant(xl, yl))
+            |> Result.fmap(a => { player: newPlayer, area: a})
       }
       | None => error(InvalidState);
     };

--- a/src/app/types.re
+++ b/src/app/types.re
@@ -103,6 +103,7 @@ module type WorldCreator = {
   let buildArea: string => area;
   let buildLevel: (string, string) => level;
   let loadWorld: (string, string) => world;
+  let loadWorldAsync: (string, string) => Js.Promise.t(world);
 };
 
 module type Places = {

--- a/src/app/world.re
+++ b/src/app/world.re
@@ -35,7 +35,7 @@ module FetchCsvBuilder = {
   let create = (player: player) => {
     let (x, y) = player.location;
     
-    Worldcreator.FetchCsvWorldBuilder.loadWorld("Dungeon 1", "Dungeon 1,Dungeon 2,Dungeon 3,Dungeon 4,Dungeon 5,Swamp,Cave")
+    Worldcreator.CsvWorldBuilder.loadWorldAsync("Dungeon 1", "Dungeon 1,Dungeon 2,Dungeon 3,Dungeon 4,Dungeon 5,Swamp,Cave")
       |> Js.Promise.then_(world => 
         world 
           |> World.currentLevel

--- a/src/app/worldcreator.re
+++ b/src/app/worldcreator.re
@@ -27,7 +27,7 @@ module CsvWorldBuilder: WorldCreator = {
 
   let addEnemy = (str, place) => {
     let randId = () => Js.Math.random() |> string_of_float;
-    let makeZombie = () => {id: randId(), name: "Zombie", stats: { health: 6, speed: 0.8, position: 0. }};
+    let makeZombie = () => {id: randId(), name: "Zombie", stats: { health: 6, speed: 1., position: 0. }};
 
     switch str {
     | "Z" => { ... place, state: Enemy(makeZombie()) }

--- a/src/app/worldcreator.re
+++ b/src/app/worldcreator.re
@@ -69,22 +69,14 @@ module CsvWorldBuilder: WorldCreator = {
 
     { current: initial, levels: levels };
   };
-};
 
-module FetchCsvWorldBuilder = {
-
-  let buildPlace = CsvWorldBuilder.buildPlace;
-  let buildArea = CsvWorldBuilder.buildArea;
-
-  let buildLevel = CsvWorldBuilder.buildLevel;
-  let loadWorld = (initial, names) => {
+  let loadWorldAsync = (initial, names) => {
 
     let levelNames = Js.String.split(",", names) |> Array.to_list;
 
     let prom = (name) => Js.Promise.(
       Fetch.fetch("http://localhost:3000/world/" ++ name ++ ".csv")
         |> then_(Fetch.Response.text)
-        |> then_(t => {Js.Console.log("Got: " ++ t); t |> resolve})
         |> then_(text => buildLevel(name, text) |> resolve)
     );
 
@@ -95,3 +87,4 @@ module FetchCsvWorldBuilder = {
       |> Js.Promise.then_(lvl => lvl |> Array.to_list |> lvs => {current: initial, levels: lvs} |> Js.Promise.resolve);
   };
 };
+

--- a/src/app/worldcreator.re
+++ b/src/app/worldcreator.re
@@ -27,7 +27,7 @@ module CsvWorldBuilder: WorldCreator = {
 
   let addEnemy = (str, place) => {
     let randId = () => Js.Math.random() |> string_of_float;
-    let makeZombie = () => {id: randId(), name: "Zombie", stats: { health: 6, speed: 1., position: 0. }};
+    let makeZombie = () => {id: randId(), name: "Zombie", stats: { health: 6, speed: 0.8, position: 0. }};
 
     switch str {
     | "Z" => { ... place, state: Enemy(makeZombie()) }

--- a/src/test/bouken_test.re
+++ b/src/test/bouken_test.re
@@ -64,6 +64,9 @@ describe("Game.MovePlayer", () => {
     test("Initial turn is 0", (_) => {
       expect(initGame.turn) |> toBe(0.);
     });
+    Skip.test("Movement penalties are increased", (_) => {
+      expect(res.turn) |> toBeGreaterThan(1.1);
+    });
   });
 });
 

--- a/src/test/bouken_test.re
+++ b/src/test/bouken_test.re
@@ -39,35 +39,6 @@ describe("Game.MovePlayer", () => {
       expect(newGame.turn) |> toBeGreaterThan(1.);
     });
   });
-
-  describe("When the player is in water", () => {
-    let game = Game.create("dave");
-    let ply = {name: "test", stats: { health: 10, speed: 1.0, position: 1. }, gold: 5, location: (6, 6)};
-    let newLevel = Level.LevelBuilder.makeWaterLevel("Dungeon 1")
-      |> Level.Level.modifyTile(6, 6, 
-        {tile: WATER, 
-          state: Player(ply), 
-        });
-
-    let newWorld = World.World.updateLevel(newLevel, game.world);
-    let initGame = { ... game, world: newWorld, player: ply };
-
-    let optGame = initGame |> Game.movePlayer(-1, -1);
-    let res = optGame |> g => switch(g) {
-      | Ok(game) => game
-      | _ => initGame
-      };
-
-    test("The player moves", (_) => {
-      expect(res.player.location) |> toEqual((5, 5));
-    });
-    test("Initial turn is 0", (_) => {
-      expect(initGame.turn) |> toBe(0.);
-    });
-    Skip.test("Movement penalties are increased", (_) => {
-      expect(res.turn) |> toBeGreaterThan(1.1);
-    });
-  });
 });
 
 describe("Game.UseStairs", () => {

--- a/src/test/bouken_test.re
+++ b/src/test/bouken_test.re
@@ -34,6 +34,36 @@ describe("Game.MovePlayer", () => {
     test("The Player's location is updated to (5,5)", (_) => {
       expect(newGame.player.location) |> toEqual((5, 5));
     });
+
+    test("Moving increases the turn counter", () => {
+      expect(newGame.turn) |> toBeGreaterThan(1.);
+    });
+  });
+
+  describe("When the player is in water", () => {
+    let game = Game.create("dave");
+    let ply = {name: "test", stats: { health: 10, speed: 1.0, position: 1. }, gold: 5, location: (6, 6)};
+    let newLevel = Level.LevelBuilder.makeWaterLevel("Dungeon 1")
+      |> Level.Level.modifyTile(6, 6, 
+        {tile: WATER, 
+          state: Player(ply), 
+        });
+
+    let newWorld = World.World.updateLevel(newLevel, game.world);
+    let initGame = { ... game, world: newWorld, player: ply };
+
+    let optGame = initGame |> Game.movePlayer(-1, -1);
+    let res = optGame |> g => switch(g) {
+      | Ok(game) => game
+      | _ => initGame
+      };
+
+    test("The player moves", (_) => {
+      expect(res.player.location) |> toEqual((5, 5));
+    });
+    test("Initial turn is 0", (_) => {
+      expect(initGame.turn) |> toBe(0.);
+    });
   });
 });
 

--- a/src/test/level_test.re
+++ b/src/test/level_test.re
@@ -7,10 +7,10 @@ open Expect;
 
 let blankWorld = LevelBuilder.makeBlankLevel("test");
 let waterTile = { tile: WATER, state: Empty };
-
+let initialPosition = 1.;
 let initEnemy = {id: "testenemy", name: "spooky thing", stats: { health: 3, speed: 1.0, position: 0. }};
-let playerAt = (x, y) => Player({name:"test", stats: { health: 10, speed: 1.0, position: 0. }, gold: 5, location: (x, y)});
-let nfPlayer = { name:"test", stats: { health: 10, speed: 1.0, position: 0. }, gold: 5, location: (9, 9) };
+let playerAt = (x, y) => Player({name:"test", stats: { health: 10, speed: 1.0, position: initialPosition }, gold: 5, location: (x, y)});
+let nfPlayer = { name:"test", stats: { health: 10, speed: 1.0, position: initialPosition }, gold: 5, location: (9, 9) };
 
 describe("Level.modify", () => {
   test("Can modify a tile", (_) => {
@@ -126,22 +126,22 @@ describe("Level.movePlayer", () => {
 
 describe("Area", () => {
   describe("findPlayer", () => {
-  test("Can find the player", (_) => {
-    let player =
-      blankWorld
-      |> Level.modifyTile(0, 0, {tile: GROUND, state: playerAt(0, 0)}) 
-      |> w => w.map |> Area.findPlayer;
-    
-      expect(Rationale.Option.isSome(player)) |> toEqual(true);
-  });
-  test("Returns none when there is no player", (_) => {
-    let player =
-      blankWorld
-      |> w => w.map |> Area.findPlayer;
-    
+    test("Can find the player", (_) => {
+      let player =
+        blankWorld
+        |> Level.modifyTile(0, 0, {tile: GROUND, state: playerAt(0, 0)}) 
+        |> w => w.map |> Area.findPlayer;
+      
+        expect(Rationale.Option.isSome(player)) |> toEqual(true);
+    });
+    test("Returns none when there is no player", (_) => {
+      let player =
+        blankWorld
+        |> w => w.map |> Area.findPlayer;
+      
       expect(Rationale.Option.isSome(player)) |> toEqual(false);
+    });
   });
-});
 
   describe("findEnemy", () => {
     test("Can find an enemy", (_) => {
@@ -161,4 +161,27 @@ describe("Area", () => {
         expect(Rationale.Option.isSome(enemy)) |> toEqual(false);
     });
   });
+
+
+  describe("movePlayer", () => {
+    describe("When the Player is on a ground tile", () => {
+      let areaResult =
+          blankWorld
+            |> Level.modifyTile(2, 2, {tile: GROUND, state: playerAt(2, 2)})
+            |> level => level.map
+            |> Area.movePlayer(1, 0, 1.)
+            |> Rationale.Option.ofResult;
+
+      let playerArea = areaResult |> Rationale.Option.default({ player: nfPlayer, area: [[]]});
+
+      test("The move is successful", (_) => {  
+        expect(Rationale.Option.isSome(areaResult)) |> toEqual(true);
+      });
+
+      Skip.test("The player's position is reduced", (_) => {  
+        expect(playerArea.player.stats.position) |> toBeLessThan(1.);
+      });
+    });
+  });
 });
+

--- a/src/test/level_test.re
+++ b/src/test/level_test.re
@@ -185,10 +185,6 @@ describe("Area", () => {
       test("The player is updated ", (_) => {  
         expect(playerArea.area |> Area.findPlayer |> Option.default(nfPlayer) |> p => p.stats.position) |> toBeCloseTo(0.);
       });
-
-      Skip.test("The player's position is reduced", (_) => {  
-        expect(playerArea.player.stats.position) |> toBeLessThan(1.);
-      });
     });
 
     describe("When the Player is on a water tile", () => {
@@ -212,11 +208,6 @@ describe("Area", () => {
       test("The player in the area updated ", (_) => {  
         expect(playerArea.area |> Area.findPlayer |> Option.default(nfPlayer) |> p => p.stats.position) |> toBeCloseTo(-0.5);
       });
-
-      Skip.test("The player returned's position is reduced", (_) => {  
-        expect(playerArea.player.stats.position) |> toBeLessThan(1.);
-      });
     });
   });
 });
-

--- a/src/test/level_test.re
+++ b/src/test/level_test.re
@@ -178,7 +178,42 @@ describe("Area", () => {
         expect(Rationale.Option.isSome(areaResult)) |> toEqual(true);
       });
 
+      test("The player still exists", (_) => {  
+        expect(playerArea.area |> Area.findPlayer |> Option.isSome) |> toBe(true);
+      });
+
+      test("The player is updated ", (_) => {  
+        expect(playerArea.area |> Area.findPlayer |> Option.default(nfPlayer) |> p => p.stats.position) |> toBeCloseTo(0.);
+      });
+
       Skip.test("The player's position is reduced", (_) => {  
+        expect(playerArea.player.stats.position) |> toBeLessThan(1.);
+      });
+    });
+
+    describe("When the Player is on a water tile", () => {
+      let areaResult =
+          LevelBuilder.makeWaterLevel("waterLevel")
+            |> Level.modifyTile(2, 2, {tile: WATER, state: playerAt(2, 2)})
+            |> level => level.map
+            |> Area.movePlayer(1, 0, 1.)
+            |> Rationale.Option.ofResult;
+
+      let playerArea = areaResult |> Rationale.Option.default({ player: nfPlayer, area: [[]]});
+
+      test("The move is successful", (_) => {  
+        expect(Rationale.Option.isSome(areaResult)) |> toEqual(true);
+      });
+
+      test("The player still exists", (_) => {  
+        expect(playerArea.area |> Area.findPlayer |> Option.isSome) |> toBe(true);
+      });
+
+      test("The player in the area updated ", (_) => {  
+        expect(playerArea.area |> Area.findPlayer |> Option.default(nfPlayer) |> p => p.stats.position) |> toBeCloseTo(-0.5);
+      });
+
+      Skip.test("The player returned's position is reduced", (_) => {  
         expect(playerArea.player.stats.position) |> toBeLessThan(1.);
       });
     });


### PR DESCRIPTION
Initial support for terrain penalties e.g. slow movement and attacks whilst on water tiles.

- [x] Movement penalty for Player & Enemies
- [x] Attack penalty
- [x] Improve testing around movement